### PR TITLE
docs: add usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@
 Weekly build of alpine image with curl, wget and jq.
 
 Images on [Docker Hub](https://hub.docker.com/r/apteno/alpine-jq)
+
+## Example
+
+Pull the image and pipe JSON through `jq`:
+
+```sh
+docker run --rm apteno/alpine-jq sh -c \
+  "curl -s https://api.github.com/repos/apteno/alpine-jq | jq '.full_name, .stargazers_count'"
+```
+
+Use it as a base image in your own `Dockerfile`:
+
+```dockerfile
+FROM apteno/alpine-jq
+
+COPY script.sh /script.sh
+ENTRYPOINT ["/script.sh"]
+```


### PR DESCRIPTION
## Summary
- Add a runnable example that pipes a `curl` response through `jq`
- Add a `Dockerfile` snippet showing how to use the image as a base

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Run the example command locally to confirm it works


---
_Generated by [Claude Code](https://claude.ai/code/session_01SvRk9oi9zmKSuQmxbMvVas)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added practical usage examples showing how to run the Docker image for processing GitHub repository data
  * Added sample Dockerfile configuration reference for reproducibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->